### PR TITLE
Add docs & gh pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - run: sudo apt-get install libnetcdf-dev
+      - run: sudo apt-get install libnetcdff-dev
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /Manifest.toml
+docs/Manifest.toml
 *.gif
 *AIBECS*backup*jl

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 **Speakers:** [Gael Forget](https://github.com/gaelforget), [Benoit Pasquier](https://github.com/briochemc), [Zhen Wu](https://github.com/zhenwu0728)
 
-## Will stream on youtube at 2pm UTC on Sunday 2021/07/25
+## 2021/07/25 Workshop Recording
 
 streaming : https://www.youtube.com/watch?v=UCIRrXz2ZS0
 
 webpage : https://pretalx.com/juliacon2021/talk/FEZW9Q/
 
-<img src="https://user-images.githubusercontent.com/20276764/126787920-fb0fc858-366e-44cb-822b-6ceb8aa814fa.png" width="90%">
+[<img src="https://user-images.githubusercontent.com/20276764/132381907-1ab7d682-ea3d-4db7-b245-3cdb9dd2dcd3.png" width="75%">](https://www.youtube.com/watch?v=UCIRrXz2ZS0)
 
 ## Abstract
 
@@ -46,9 +46,7 @@ The workshop will be organized around tutorials and self-contained Pluto noteboo
 
 - Q&A, tutorials, etc wrap-up
 
-Workshop materials will be made available ahead of time @ https://github.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl
-
-
+Workshop materials are available ahead of time @ https://github.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ webpage : https://pretalx.com/juliacon2021/talk/FEZW9Q/
 
 Life in the oceans is strongly connected to our climate. In this workshop, you will learn to use packages from the [JuliaOcean](https://github.com/JuliaOcean) and [JuliaClimate](https://github.com/JuliaClimate) organizations that provide a foundation for studying marine ecosystems across a wide range of scales. We will run agent-based models to explore individual microbes and processes that drive species interactions. On the other end of the model hierarchy, we will simulate planetary-scale transports that control ocean biogeography and climate change.
 
-
-
-
-
-
 ## Description
 
 Packages covered in this workshop will include:
@@ -30,7 +25,7 @@ Packages covered in this workshop will include:
 - [MITgcmTools.jl](https://github.com/gaelforget/MITgcmTools.jl): interface to full-featured, Fortran-based, general circulation model and its output (transports, chemistry, ecology, ocean, sea-ice, atmosphere, and more).
 - [IndividualDisplacements.jl](https://github.com/JuliaClimate/IndividualDisplacements.jl): local to global particle tracking, for simulating dispersion, connectivity, transports in the ocean or atmosphere, etc.
 
-The workshop will be organized around tutorials and self-contained Pluto notebooks for the different packages.
+The workshop was organized around tutorials and self-contained Pluto notebooks for the different packages.
 
 ## Schedule
 
@@ -55,11 +50,11 @@ Workshop materials are available ahead of time @ https://github.com/JuliaOcean/M
 
 To run the notebooks of this workshop on your machine, you need to:
 
-1. **Install Julia** from <https://julialang.org/> (latest version is v1.6.2).
+1. **Install Julia** from <https://julialang.org/> (latest version is v1.6.2)
 
-1. **Start Julia.**
+1. **Start Julia**
 
-1. **Add the Pluto package (v0.15.0 or later).**
+1. **Add Pluto.jl** (v0.15.0 or later)**
 
     This is simply done by typing, in the julia REPL,
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+PlutoSliderServer = "2fc8631c-6f24-4c5b-bca7-cbb509c42db4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,24 @@
+using Documenter, MarineEcosystemsJuliaCon2021
+import PlutoSliderServer
+using Plots
+
+makedocs(;
+    modules=[MarineEcosystemsJuliaCon2021],
+    format=Documenter.HTML(),
+    repo="https://github.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/blob/{commit}{path}#L{line}",
+    sitename="MarineEcosystemsJuliaCon2021.jl",
+    authors="gaelforget <gforget@mit.edu>",
+)
+
+pth = joinpath(@__DIR__, "build")
+lst=("AIBECSExample.jl","PlanktonIndividualExample.jl","MITgcm_tutorial_global_oce_biogeo.jl","IndividualDisplacementsExample.jl")
+for i in lst
+    fil_in=joinpath(@__DIR__,"..","src",i)
+    fil_out=joinpath(pth,i[1:end-2]*"html")
+    PlutoSliderServer.export_notebook(fil_in)
+    mv(fil_in[1:end-2]*"html",fil_out)
+end
+
+deploydocs(;
+    repo="github.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl",
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ for i in lst
     fil_out=joinpath(pth,i[1:end-2]*"html")
     PlutoSliderServer.export_notebook(fil_in)
     mv(fil_in[1:end-2]*"html",fil_out)
+    cp(fil_in,fil_out[1:end-4]*"jl")
 end
 
 deploydocs(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,11 +8,11 @@
 
 ## 2021/07/25 Workshop Recording
 
-streaming : https://www.youtube.com/watch?v=UCIRrXz2ZS0
+streaming : <https://www.youtube.com/watch?v=UCIRrXz2ZS0>
 
-webpage : https://pretalx.com/juliacon2021/talk/FEZW9Q/
+webpage : <https://pretalx.com/juliacon2021/talk/FEZW9Q/>
 
-[<img src="https://user-images.githubusercontent.com/20276764/132381907-1ab7d682-ea3d-4db7-b245-3cdb9dd2dcd3.png" width="75%">](https://www.youtube.com/watch?v=UCIRrXz2ZS0)
+[![video link](https://user-images.githubusercontent.com/20276764/132381907-1ab7d682-ea3d-4db7-b245-3cdb9dd2dcd3.png)](https://www.youtube.com/watch?v=UCIRrXz2ZS0)
 
 ## Abstract
 
@@ -20,7 +20,9 @@ Life in the oceans is strongly connected to our climate. In this workshop, you w
 
 ## Notebooks
 
-Any example found in the online documentation is most easily run using [Pluto.jl](https://github.com/fonsp/Pluto.jl). Just copy the corresponding `notebook url` link below and paste into the [Pluto.jl interface](https://github.com/fonsp/Pluto.jl/wiki/🔎-Basic-Commands-in-Pluto).
+Any example found in the online documentation is most easily run using [Pluto.jl](https://github.com/fonsp/Pluto.jl) . 
+
+Just copy the corresponding `notebook url` link below and paste into the [Pluto.jl interface](https://github.com/fonsp/Pluto.jl/wiki/🔎-Basic-Commands-in-Pluto) (v0.15 or later).
 
 - [AIBECSExample.html](AIBECSExample.html) (---> [notebook url](AIBECSExample.jl))
 - [PlanktonIndividualExample.html](PlanktonIndividualExample.html) (---> [notebook url](PlanktonIndividualExample.jl))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,38 @@
 # MarineEcosystemsJuliaCon2021.jl
 
-G.F., B.P., Z.W.
+[JuliaCon 2021](https://juliacon.org/2021/) Workshop
 
-- [AIBECSExample.html](AIBECSExample.html)
-- [PlanktonIndividualExample.html](PlanktonIndividualExample.html)
-- [MITgcm_tutorial_global_oce_biogeo.html](MITgcm_tutorial_global_oce_biogeo.html)
-- [IndividualDisplacementsExample.html](IndividualDisplacementsExample.html)
+**Title:** Modeling Marine Ecosystems At Multiple Scales Using Julia
+
+**Speakers:** [Gael Forget](https://github.com/gaelforget), [Benoit Pasquier](https://github.com/briochemc), [Zhen Wu](https://github.com/zhenwu0728)
+
+## 2021/07/25 Workshop Recording
+
+streaming : https://www.youtube.com/watch?v=UCIRrXz2ZS0
+
+webpage : https://pretalx.com/juliacon2021/talk/FEZW9Q/
+
+[<img src="https://user-images.githubusercontent.com/20276764/132381907-1ab7d682-ea3d-4db7-b245-3cdb9dd2dcd3.png" width="75%">](https://www.youtube.com/watch?v=UCIRrXz2ZS0)
+
+## Abstract
+
+Life in the oceans is strongly connected to our climate. In this workshop, you will learn to use packages from the [JuliaOcean](https://github.com/JuliaOcean) and [JuliaClimate](https://github.com/JuliaClimate) organizations that provide a foundation for studying marine ecosystems across a wide range of scales. We will run agent-based models to explore individual microbes and processes that drive species interactions. On the other end of the model hierarchy, we will simulate planetary-scale transports that control ocean biogeography and climate change.
+
+## Notebooks
+
+Any example found in the online documentation is most easily run using [Pluto.jl](https://github.com/fonsp/Pluto.jl). Just copy the corresponding `notebook url` link below and paste into the [Pluto.jl interface](https://github.com/fonsp/Pluto.jl/wiki/🔎-Basic-Commands-in-Pluto).
+
+- [AIBECSExample.html](AIBECSExample.html) (---> [notebook url](AIBECSExample.jl))
+- [PlanktonIndividualExample.html](PlanktonIndividualExample.html) (---> [notebook url](PlanktonIndividualExample.jl))
+- [MITgcm_tutorial_global_oce_biogeo.html](MITgcm_tutorial_global_oce_biogeo.html) (---> [notebook url](MITgcm_tutorial_global_oce_biogeo.jl))
+- [IndividualDisplacementsExample.html](IndividualDisplacementsExample.html) (---> [notebook url](IndividualDisplacementsExample.jl))
+
+## Description
+
+Packages covered in this workshop will include:
+
+- [AIBECS.jl](https://github.com/JuliaOcean/AIBECS.jl): global steady-state biogeochemistry and gridded transport models that run fast for long time scales (centuries or even millennia).
+- [PlanktonIndividuals.jl](https://github.com/JuliaOcean/PlanktonIndividuals.jl): local to global agent-based model, particularly suited to study microbial communities, plankton physiology, and nutrient cycles.
+- [MITgcmTools.jl](https://github.com/gaelforget/MITgcmTools.jl): interface to full-featured, Fortran-based, general circulation model and its output (transports, chemistry, ecology, ocean, sea-ice, atmosphere, and more).
+- [IndividualDisplacements.jl](https://github.com/JuliaClimate/IndividualDisplacements.jl): local to global particle tracking, for simulating dispersion, connectivity, transports in the ocean or atmosphere, etc.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,9 @@
+# MarineEcosystemsJuliaCon2021.jl
+
+G.F., B.P., Z.W.
+
+- [AIBECSExample.html](AIBECSExample.html)
+- [PlanktonIndividualExample.html](PlanktonIndividualExample.html)
+- [MITgcm_tutorial_global_oce_biogeo.html](MITgcm_tutorial_global_oce_biogeo.html)
+- [IndividualDisplacementsExample.html](IndividualDisplacementsExample.html)
+

--- a/src/Workshop_Intro_Slides.ipynb
+++ b/src/Workshop_Intro_Slides.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "391b6a9f",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# [JuliaCon 2021](https://juliacon.org/2021/) Workshop\n",
+    "\n",
+    "**Title:** Modeling Marine Ecosystems At Multiple Scales Using Julia\n",
+    "\n",
+    "**Speakers:** [Gael Forget](https://github.com/gaelforget), [Benoit Pasquier](https://github.com/briochemc), [Zhen Wu](https://github.com/zhenwu0728)\n",
+    "\n",
+    "- material : <https://github.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl>\n",
+    "- streaming : <https://www.youtube.com/watch?v=UCIRrXz2ZS0>\n",
+    "- Q & A : <https://pigeonhole.at/MARINE>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec9efeb7",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Life in the oceans is strongly connected to our climate. In this workshop, you will learn to use packages from the [JuliaOcean](https://github.com/JuliaOcean) and [JuliaClimate](https://github.com/JuliaClimate) organizations that provide a foundation for studying marine ecosystems across a wide range of scales. We will run agent-based models to explore individual microbes and processes that drive species interactions. On the other end of the model hierarchy, we will simulate planetary-scale transports that control ocean biogeography and climate change."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70a88e26",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Schedule\n",
+    "\n",
+    "- Introduction of the topics covered, presenters, installation, and workshop roadmap (15 minutes).\n",
+    "\n",
+    "- [AIBECS.jl](https://github.com/JuliaOcean/AIBECS.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/AIBECSExample.jl))\n",
+    "\n",
+    "- [PlanktonIndividuals.jl](https://github.com/JuliaOcean/PlanktonIndividuals.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/PlanktonIndividualExample.jl))\n",
+    "\n",
+    "- [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [MITgcmTools.jl](https://github.com/gaelforget/MITgcmTools.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/MITgcm_tutorial_global_oce_biogeo.jl))\n",
+    "\n",
+    "- [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [IndividualDisplacements.jl](https://github.com/JuliaClimate/IndividualDisplacements.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/IndividualDisplacementsExample.jl))\n",
+    "\n",
+    "- Q&A, tutorials, etc wrap-up\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "738fbd4d",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Context\n",
+    "\n",
+    "- marine ecosystems and climate: \n",
+    "    - from microbes O($10^{-6}m$) to whole Earth O($10^6$m); from seconds to millenia\n",
+    "    - life in a moving fluid; interactions between physics, chemistry, and biology\n",
+    "    - many fascinating and crucial questions w.r.t. climate change (carbon, food, biodiversity, ...)\n",
+    "- hierarchy of models :\n",
+    "    - single ODE to massively parallel HPC simulations\n",
+    "    - various languages; julia as the future and to unify"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24e123cf",
+   "metadata": {
+    "cell_style": "split",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "source": [
+    "<img src=\"https://github.com/JuliaOcean/PlanktonIndividuals.jl/raw/master/docs/src/PI_Quota.jpeg\" width=\"90%\">\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af4511ab",
+   "metadata": {
+    "cell_style": "split",
+    "slideshow": {
+     "slide_type": "-"
+    }
+   },
+   "source": [
+    "<img src=\"https://mitgcm.readthedocs.io/en/latest/_images/co2flux.png\" width=\"90%\">\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c3f1074",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "- Github Organizations : \n",
+    "    - JuliaOcean\n",
+    "    - JuliaClimate\n",
+    "    - ...\n",
+    "- Funding / Support : \n",
+    "    - NASA (PO, MAP, IDS)\n",
+    "    - Simons Foundation (CBIOMES, Scope, Gradients)\n",
+    "    - ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "201843f1",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## How To \n",
+    "\n",
+    "To run the notebooks of this workshop on your machine, you need to:\n",
+    "\n",
+    "1. **Install julia** (v1.6.0 or later, <https://julialang.org/>)\n",
+    "\n",
+    "1. **Start julia**\n",
+    "\n",
+    "1. **Add Pluto.jl** (v0.15.0 or later, https://github.com/fonsp/Pluto.jl)\n",
+    "\n",
+    "    ```julia\n",
+    "    import Pkg\n",
+    "    Pkg.add(\"Pluto\")\n",
+    "    ```\n",
+    "\n",
+    "1. **Use Pluto to run a notebook**\n",
+    "\n",
+    "    ```julia\n",
+    "    using Pluto\n",
+    "    Pluto.run(notebook=\"https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/AIBECSExample.jl\")\n",
+    "    ```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "062fae02",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "**Alternatively**, instead of your own computer, you can just launch a Pluto instance in the cloud using [JuliaHub.com](https://juliahub.com/ui/Home), paste a notebook URL in the [Pluto start page](https://github.com/fonsp/Pluto.jl), and click open."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e7e5c4a",
+   "metadata": {
+    "lines_to_next_cell": 0,
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Schedule\n",
+    "\n",
+    "- Introduction of the topics covered, presenters, installation, and workshop roadmap (15 minutes).\n",
+    "\n",
+    "- [AIBECS.jl](https://github.com/JuliaOcean/AIBECS.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/AIBECSExample.jl))\n",
+    "\n",
+    "- [PlanktonIndividuals.jl](https://github.com/JuliaOcean/PlanktonIndividuals.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/PlanktonIndividualExample.jl))\n",
+    "\n",
+    "- [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [MITgcmTools.jl](https://github.com/gaelforget/MITgcmTools.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/MITgcm_tutorial_global_oce_biogeo.jl))\n",
+    "\n",
+    "- [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [IndividualDisplacements.jl](https://github.com/JuliaClimate/IndividualDisplacements.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/IndividualDisplacementsExample.jl))\n",
+    "\n",
+    "- Q&A, tutorials, etc wrap-up\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Slideshow",
+  "jupytext": {
+   "formats": "ipynb,jl:light"
+  },
+  "kernelspec": {
+   "display_name": "Julia 1.6.0",
+   "language": "julia",
+   "name": "julia-1.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.6.0"
+  },
+  "rise": {
+   "autolaunch": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/Workshop_Intro_Slides.jl
+++ b/src/Workshop_Intro_Slides.jl
@@ -1,0 +1,117 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,jl:light
+#     text_representation:
+#       extension: .jl
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.11.3
+#   kernelspec:
+#     display_name: Julia 1.6.0
+#     language: julia
+#     name: julia-1.6
+# ---
+
+# + [markdown] slideshow={"slide_type": "slide"}
+# # [JuliaCon 2021](https://juliacon.org/2021/) Workshop
+#
+# **Title:** Modeling Marine Ecosystems At Multiple Scales Using Julia
+#
+# **Speakers:** [Gael Forget](https://github.com/gaelforget), [Benoit Pasquier](https://github.com/briochemc), [Zhen Wu](https://github.com/zhenwu0728)
+#
+# - material : <https://github.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl>
+# - streaming : <https://www.youtube.com/watch?v=UCIRrXz2ZS0>
+# - Q & A : <https://pigeonhole.at/MARINE>
+
+# + [markdown] slideshow={"slide_type": "subslide"}
+# Life in the oceans is strongly connected to our climate. In this workshop, you will learn to use packages from the [JuliaOcean](https://github.com/JuliaOcean) and [JuliaClimate](https://github.com/JuliaClimate) organizations that provide a foundation for studying marine ecosystems across a wide range of scales. We will run agent-based models to explore individual microbes and processes that drive species interactions. On the other end of the model hierarchy, we will simulate planetary-scale transports that control ocean biogeography and climate change.
+
+# + [markdown] slideshow={"slide_type": "slide"}
+# ## Schedule
+#
+# - Introduction of the topics covered, presenters, installation, and workshop roadmap (15 minutes).
+#
+# - [AIBECS.jl](https://github.com/JuliaOcean/AIBECS.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/AIBECSExample.jl))
+#
+# - [PlanktonIndividuals.jl](https://github.com/JuliaOcean/PlanktonIndividuals.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/PlanktonIndividualExample.jl))
+#
+# - [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [MITgcmTools.jl](https://github.com/gaelforget/MITgcmTools.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/MITgcm_tutorial_global_oce_biogeo.jl))
+#
+# - [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [IndividualDisplacements.jl](https://github.com/JuliaClimate/IndividualDisplacements.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/IndividualDisplacementsExample.jl))
+#
+# - Q&A, tutorials, etc wrap-up
+#
+
+# + [markdown] slideshow={"slide_type": "slide"}
+# ## Context
+#
+# - marine ecosystems and climate: 
+#     - from microbes O($10^{-6}m$) to whole Earth O($10^6$m); from seconds to millenia
+#     - life in a moving fluid; interactions between physics, chemistry, and biology
+#     - many fascinating and crucial questions w.r.t. climate change (carbon, food, biodiversity, ...)
+# - hierarchy of models :
+#     - single ODE to massively parallel HPC simulations
+#     - various languages; julia as the future and to unify
+
+# + [markdown] slideshow={"slide_type": "-"} cell_style="split"
+# <img src="https://github.com/JuliaOcean/PlanktonIndividuals.jl/raw/master/docs/src/PI_Quota.jpeg" width="90%">
+#
+#
+
+# + [markdown] slideshow={"slide_type": "-"} cell_style="split"
+# <img src="https://mitgcm.readthedocs.io/en/latest/_images/co2flux.png" width="90%">
+#
+#
+
+# + [markdown] slideshow={"slide_type": "subslide"}
+# - Github Organizations : 
+#     - JuliaOcean
+#     - JuliaClimate
+#     - ...
+# - Funding / Support : 
+#     - NASA (PO, MAP, IDS)
+#     - Simons Foundation (CBIOMES, Scope, Gradients)
+#     - ...
+
+# + [markdown] slideshow={"slide_type": "slide"}
+# ## How To 
+#
+# To run the notebooks of this workshop on your machine, you need to:
+#
+# 1. **Install julia** (v1.6.0 or later, <https://julialang.org/>)
+#
+# 1. **Start julia**
+#
+# 1. **Add Pluto.jl** (v0.15.0 or later, https://github.com/fonsp/Pluto.jl)
+#
+#     ```julia
+#     import Pkg
+#     Pkg.add("Pluto")
+#     ```
+#
+# 1. **Use Pluto to run a notebook**
+#
+#     ```julia
+#     using Pluto
+#     Pluto.run(notebook="https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/AIBECSExample.jl")
+#     ```
+
+# + [markdown] slideshow={"slide_type": "subslide"}
+# **Alternatively**, instead of your own computer, you can just launch a Pluto instance in the cloud using [JuliaHub.com](https://juliahub.com/ui/Home), paste a notebook URL in the [Pluto start page](https://github.com/fonsp/Pluto.jl), and click open.
+
+# + [markdown] slideshow={"slide_type": "slide"}
+# ## Schedule
+#
+# - Introduction of the topics covered, presenters, installation, and workshop roadmap (15 minutes).
+#
+# - [AIBECS.jl](https://github.com/JuliaOcean/AIBECS.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/AIBECSExample.jl))
+#
+# - [PlanktonIndividuals.jl](https://github.com/JuliaOcean/PlanktonIndividuals.jl): concept, implementation, tutorial workthough (30 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/PlanktonIndividualExample.jl))
+#
+# - [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [MITgcmTools.jl](https://github.com/gaelforget/MITgcmTools.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/MITgcm_tutorial_global_oce_biogeo.jl))
+#
+# - [ClimateModels.jl](https://github.com/gaelforget/ClimateModels.jl) and [IndividualDisplacements.jl](https://github.com/JuliaClimate/IndividualDisplacements.jl): concept, implementation, tutorial workthough (20 minutes + 10' for questions; [this notebook URL](https://raw.githubusercontent.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/main/src/IndividualDisplacementsExample.jl))
+#
+# - Q&A, tutorials, etc wrap-up
+#


### PR DESCRIPTION
This is aiming to do with these notebooks what I did in https://gaelforget.github.io/MITgcmTools.jl/dev/examples/ (try the links in that page)

i.e. convert to html during the docs build process and host online via Documenter.jl and gh-pages

- add docs + ci.yaml
- make.jl calls PlutoSliderServer.export_notebook which generates html
- generated html file is placed inside docs/build, linked inside docs/build/index.html

ps. this PR also includes https://github.com/JuliaOcean/MarineEcosystemsJuliaCon2021.jl/pull/19